### PR TITLE
fix: Bump to node20 to avoid deprecation warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,5 +63,5 @@ inputs:
     required: false
     default: 'true'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
As per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20

---
name: Default pull request template
about: This is a pull request blank.
title: ''
labels: ''
assignees: slavcodev

---

## Details

Trivial node version bump.
